### PR TITLE
Calculate the time based policy violation correctly

### DIFF
--- a/lib/lts/index.js
+++ b/lib/lts/index.js
@@ -146,6 +146,7 @@ function isLtsOrLatest(info, resolvedVersion, currentDate /* this used for testi
   let packageName = 'node';
   let message = '';
   let duration = 0;
+  let deprecationDate = 0;
 
   const today = currentDate || new Date();
   if (info.type == 'node') {
@@ -164,6 +165,7 @@ function isLtsOrLatest(info, resolvedVersion, currentDate /* this used for testi
             if (isMaintenanceLts) {
               message = 'Using maintenance LTS. Update to latest LTS';
               duration = dateDiff(new Date(data.end_date), today);
+              deprecationDate = data.end_date;
             }
             return true;
           }
@@ -187,6 +189,7 @@ function isLtsOrLatest(info, resolvedVersion, currentDate /* this used for testi
         if (isMaintenanceLts) {
           message = 'Using maintenance LTS. Update to latest LTS';
           duration = dateDiff(new Date(data.end_date), today);
+          deprecationDate = data.end_date;
         }
         return true;
       }
@@ -202,6 +205,7 @@ function isLtsOrLatest(info, resolvedVersion, currentDate /* this used for testi
 
     if (isExpiringSoon(duration)) {
       returnVal['duration'] = duration;
+      returnVal['deprecationDate'] = deprecationDate;
       returnVal['message'] = message;
     }
 
@@ -221,6 +225,7 @@ function isLtsOrLatest(info, resolvedVersion, currentDate /* this used for testi
       ) {
         version = key;
         duration = dateDiff(today, new Date(data.start_date));
+        deprecationDate = data.start_date;
         return true;
       }
     });
@@ -229,6 +234,7 @@ function isLtsOrLatest(info, resolvedVersion, currentDate /* this used for testi
       isSupported: false,
       message: `${packageName} needs to be on v${version} or above LTS version`,
       duration,
+      deprecationDate,
       type: info.type == 'node' ? 'node' : 'ember',
     };
   }

--- a/lib/output/cli-output.js
+++ b/lib/output/cli-output.js
@@ -2,7 +2,7 @@
 
 const chalk = require('chalk');
 const Table = require('cli-table');
-const { isExpiringSoon, MILLSINQUARTER } = require('../util');
+const { isExpiringSoon } = require('../util');
 const {
   LOG_TITLE,
   LOG_SEMVER_VIOLATION,
@@ -10,7 +10,6 @@ const {
   LOG_SEMVER_TITLE,
   LOG_POLICY_TITLE,
   DEFAULT_SUPPORT_MESSAGE,
-  getQtrLocale,
 } = require('./messages');
 
 // CONSTANTS
@@ -53,85 +52,60 @@ function getBodyContent(results, flags) {
     chalk` {underline {bold {white Name}}}`,
     chalk`{underline {bold {white Resolved}}}`,
     chalk`{underline {bold {white Latest}}}`,
+    chalk`{underline {bold {white Violation Type}}}`,
+    chalk`{underline {bold {white Deprecation Date}}}`,
   ];
-  const unSupportedTable = new Table({
-    chars,
-    head: [
-      ...headings,
-      chalk`{underline {bold {white Violation Type}}}`,
-      chalk`{underline {bold {white Unsupported Since}}}`,
-    ],
-  });
-  const expiringSoonTable = new Table({
-    chars,
-    head: [
-      ...headings,
-      chalk`{underline {bold {white Violation Type}}}`,
-      chalk`{underline {bold {white Unsupported In}}}`,
-    ],
-  });
-  const supportedTable = new Table({
-    chars,
-    head: headings,
-  });
-  results.forEach(({ name, resolvedVersion, latestVersion, duration, type, isSupported }) => {
-    if (!isSupported) {
-      let qtrs = '';
-      if (Number.isInteger(duration)) {
-        qtrs = Math.ceil(duration / MILLSINQUARTER);
-        qtrs = `${qtrs} ${getQtrLocale(qtrs)}`;
-      }
-      unSupportedTable.push([
-        chalk` {red ${name}}`,
-        chalk`{red ${resolvedVersion}}`,
-        chalk`{red ${latestVersion}}`,
-        chalk`{red ${type ? type : 'LTS'}}`,
-        chalk`{red ${qtrs}}`,
-      ]);
-    } else {
-      let expiresSoon = duration && isExpiringSoon(duration);
-      if (expiresSoon) {
-        const qtrs = Math.ceil(duration / MILLSINQUARTER);
-        expiringSoonTable.push([
-          chalk` {yellow ${name}}`,
-          chalk`{yellow ${resolvedVersion}}`,
-          chalk`{yellow ${latestVersion}}`,
-          chalk`{yellow ${type ? type : 'LTS'}}`,
-          expiresSoon && chalk`{yellow ${qtrs} ${getQtrLocale(qtrs)}}`,
+  const unSupportedTable = [];
+  const expiringSoonTable = [];
+  const supportedTable = [];
+  results.forEach(
+    ({ name, resolvedVersion, latestVersion, duration, type, isSupported, deprecationDate }) => {
+      if (!isSupported) {
+        unSupportedTable.push([
+          chalk` {red ${name}}`,
+          chalk`{red ${resolvedVersion}}`,
+          chalk`{red ${latestVersion}}`,
+          chalk`{red ${type ? type : 'LTS'}}`,
+          chalk`{red ${new Date(deprecationDate).toDateString()}}`,
         ]);
       } else {
-        supportedTable.push([
-          chalk` {dim ${name}}`,
-          chalk`{dim ${resolvedVersion}}`,
-          chalk`{dim ${latestVersion}}`,
-        ]);
+        let expiresSoon = duration && isExpiringSoon(duration);
+        if (expiresSoon) {
+          expiringSoonTable.push([
+            chalk` {yellow ${name}}`,
+            chalk`{yellow ${resolvedVersion}}`,
+            chalk`{yellow ${latestVersion}}`,
+            chalk`{yellow ${type ? type : 'LTS'}}`,
+            expiresSoon && chalk`{yellow ${new Date(deprecationDate).toDateString()}}`,
+          ]);
+        } else {
+          supportedTable.push([
+            chalk` {dim ${name}}`,
+            chalk`{dim ${resolvedVersion}}`,
+            chalk`{dim ${latestVersion}}`,
+          ]);
+        }
       }
-    }
+    },
+  );
+  let table = new Table({
+    chars,
+    head: [...headings],
   });
-  let table = '';
   const showUnsupported = flags.verbose || flags.unsupported;
   const showExpiring = flags.verbose || flags.expiring;
   const showSupported = flags.verbose || flags.supported;
   if (unSupportedTable.length && showUnsupported) {
-    table += chalk`
-{bgGrey {bold {red   Unsupported  }}}
-${unSupportedTable.toString()}
-    `;
+    table.push(...unSupportedTable);
   }
   if (expiringSoonTable.length && showExpiring) {
-    table += chalk`
-{bgGrey {bold {yellow   Soon to be unsupported  }}}
-${expiringSoonTable.toString()}
-    `;
+    table.push(...expiringSoonTable);
   }
   if (supportedTable.length && showSupported) {
-    table += chalk`
-{bgGrey {bold {green   Supported  }}}
-${supportedTable.toString()}
-    `;
+    table.push(...supportedTable);
   }
 
-  return table;
+  return showUnsupported || showExpiring || showSupported ? table : '';
 }
 
 /**
@@ -316,14 +290,11 @@ function makeConsoleReport(supportResult, flags, supportMessage) {
     emberPackage,
     currentPolicy,
   );
-
-  const body = getBodyContent(supportResult.supportChecks, flags);
-
-  return {
-    title,
-    head,
-    body,
-  };
+  let readjustedBody = body;
+  if (body) {
+    readjustedBody = `\n${readjustedBody}`;
+  }
+  return `${title}${head}${readjustedBody}`;
 }
 
 /**

--- a/lib/output/cli-output.js
+++ b/lib/output/cli-output.js
@@ -53,7 +53,7 @@ function getBodyContent(results, flags) {
     chalk`{underline {bold {white Resolved}}}`,
     chalk`{underline {bold {white Latest}}}`,
     chalk`{underline {bold {white Violation Type}}}`,
-    chalk`{underline {bold {white Deprecation Date}}}`,
+    chalk`{underline {bold {white End of Support}}}`,
   ];
   const unSupportedTable = [];
   const expiringSoonTable = [];
@@ -290,11 +290,14 @@ function makeConsoleReport(supportResult, flags, supportMessage) {
     emberPackage,
     currentPolicy,
   );
-  let readjustedBody = body;
-  if (body) {
-    readjustedBody = `\n${readjustedBody}`;
-  }
-  return `${title}${head}${readjustedBody}`;
+
+  const body = getBodyContent(supportResult.supportChecks, flags);
+
+  return {
+    title,
+    head,
+    body,
+  };
 }
 
 /**
@@ -388,9 +391,11 @@ function getCategorisedList(pkgList) {
  */
 function displayResult(supportResult, flags, supportMessage) {
   const { title, head, body } = makeConsoleReport(supportResult, flags, supportMessage);
-
-  console.log(`${title}${head}
-  ${body}`);
+  let readjustedBody = body;
+  if (body) {
+    readjustedBody = `\n${readjustedBody}`;
+  }
+  console.log(`${title}${head}${readjustedBody}`);
 }
 
 module.exports = {

--- a/lib/output/csv-output.js
+++ b/lib/output/csv-output.js
@@ -32,6 +32,24 @@ function writeToCsv(result, policyDetails) {
       },
     },
     {
+      label: 'Resolved Version',
+      value: 'resolvedVersion',
+    },
+    {
+      label: 'Latest Version',
+      value: 'latestVersion',
+    },
+    {
+      label: 'End of Support',
+      value: row => {
+        if (row.deprecationDate) {
+          return new Date(row.deprecationDate).toDateString();
+        } else {
+          return `-`;
+        }
+      },
+    },
+    {
       label: 'Unsupported Since/In',
       value: row => {
         if (row.duration) {
@@ -41,14 +59,6 @@ function writeToCsv(result, policyDetails) {
           return `-`;
         }
       },
-    },
-    {
-      label: 'Resolved Version',
-      value: 'resolvedVersion',
-    },
-    {
-      label: 'Latest Version',
-      value: 'latestVersion',
     },
   ];
 

--- a/lib/project/index.js
+++ b/lib/project/index.js
@@ -14,7 +14,7 @@ const { default: PQueue } = require('p-queue');
 const { supportedRanges, supported } = require('../time/index');
 const npmConfig = require('../npm/config');
 const { isLtsOrLatest } = require('../lts');
-const { sortLibraries } = require('../util');
+const { sortLibraries, getLatest } = require('../util');
 
 module.exports = async function isInSupportWindow(projectRoot) {
   const config = await npmConfig(projectRoot); // kinda slow, TODO: re-implement as standalone lib
@@ -123,14 +123,14 @@ module.exports = async function isInSupportWindow(projectRoot) {
             result = supported(
               info,
               `${name}@${resolvedVersion}`,
-              supportedRanges(info.time[info['dist-tags'].latest]),
+              supportedRanges(info.time[getLatest(info)]),
             );
           }
           supportChecks.push({
             ...result,
             name,
             resolvedVersion,
-            latestVersion: info['dist-tags'].latest,
+            latestVersion: getLatest(info),
           });
         } catch (e) {
           debug('npmFetch[fail] %o %o', meta, e);

--- a/lib/time/index.js
+++ b/lib/time/index.js
@@ -3,10 +3,12 @@
 // TODO: refactor this file
 const parsePackageName = require('parse-package-name');
 const semver = require('semver');
-const { isExpiringSoon, dateDiff } = require('../util');
+const { isExpiringSoon, dateDiff, getLatest } = require('../util');
+const moment = require('moment');
 module.exports.supportedRanges = supportedRanges;
 
-const POLICY_TYPES = ['major', 'minor', 'patch'];
+const EOQ = ['31 March', '30 June', '30 Sept', '31 Dec'];
+
 function supportedRanges(_origin) {
   const origin = new Date(_origin);
   const major = new Date(origin);
@@ -36,66 +38,93 @@ function supportedRanges(_origin) {
   ];
 }
 
-function getDate(time, version, message) {
-  const result = time[version];
-
-  if (version in time) {
-    return new Date(result);
-  } else {
-    throw new Error(message);
+module.exports.deprecationDates = deprecationDates;
+function deprecationDates(_release) {
+  const release = new Date(_release);
+  const major = new Date(release);
+  const minor = new Date(release);
+  const patch = new Date(release);
+  const releaseYear = release.getFullYear();
+  let padding = 0;
+  const isEOQ = EOQ.some(halfDate => {
+    let endOfQuarter = moment(new Date(`${halfDate} ${releaseYear}`));
+    let twoWeeksBefore = moment(new Date(`${halfDate} ${releaseYear}`)).subtract(14, 'd');
+    let releaseDate = moment(release);
+    return releaseDate.isBefore(endOfQuarter) && releaseDate.isAfter(twoWeeksBefore);
+  });
+  // if new version is released at the end of quarter do not count next quarter.
+  if (isEOQ) {
+    padding = 3;
   }
+  major.setFullYear(release.getFullYear() + 1);
+  if (padding) {
+    major.setMonth(major.getMonth() + padding);
+  }
+  minor.setMonth(release.getMonth() + 6 + padding);
+  patch.setMonth(release.getMonth() + 3 + padding);
+
+  return {
+    major,
+    minor,
+    patch,
+  };
 }
 
-module.exports.supported = supported;
-function supported(info, packageName, policies) {
-  const { name, version } = parsePackageName(packageName);
-
-  // TODO: if there is no published time, then return unsupported with cause related to lack of being published: "pre-release"
-  const current = getDate(
-    info.time,
-    version,
-    `${name}'s version: [${version}] has no published time`,
-  );
-
-  // TODO: if there is not latest, then return unsupported with caused relate to the lack of it being published: "pre-release"
-  const latestVersion = semver.parse(info['dist-tags'].latest);
-
-  const parsed = semver.parse(version);
-  let expiresSoonDuration = 0;
-  let type = '';
-  for (const policy of policies) {
-    if (POLICY_TYPES.includes(policy.type) === false) {
-      throw new Error(`Unknown Policy: '${policy.type}' for ${JSON.stringify(policy)}`);
-    }
-    if (parsed[policy.type] === latestVersion[policy.type]) {
-      continue;
-    }
-
-    const result = dateDiff(current, policy.date);
-    if (isNaN(result)) {
-      throw new Error(`Invalid Date: ${current} - ${policy.date}`);
-    }
-
-    if (result <= 0) {
-      let duration = Math.abs(result);
-      return {
-        isSupported: false,
-        message: `violated: ${policy.name}`,
-        duration,
-        type: policy.type,
-      };
-    } else {
-      expiresSoonDuration = result;
-      type = policy.type;
+module.exports.findDeprecationDate = findDeprecationDate;
+function findDeprecationDate(_version, info, type) {
+  let allRelease = info.time;
+  let versionArray = Object.keys(allRelease);
+  versionArray = versionArray.filter(version => semver.valid(version));
+  semver.sort(versionArray);
+  let indexCurrent = versionArray.indexOf(_version);
+  let currentParsed = semver.parse(_version);
+  let nextVersion = '';
+  for (let i = indexCurrent + 1; i < versionArray.length; i++) {
+    let version = semver.parse(versionArray[i]);
+    if (semver.diff(versionArray[i], currentParsed) === type) {
+      nextVersion = version;
       break;
     }
   }
-  if (isExpiringSoon(expiresSoonDuration)) {
-    return {
-      isSupported: true,
-      duration: expiresSoonDuration,
-      type,
-    };
+  return new Date(allRelease[nextVersion]);
+}
+
+module.exports.supported = supported;
+function supported(info, packageName, policies, _today) {
+  const { version } = parsePackageName(packageName);
+
+  // TODO: if there is not latest, then return unsupported with caused relate to the lack of it being published: "pre-release"
+  const latestVersion = semver.parse(getLatest(info));
+
+  const parsed = semver.parse(version);
+  let supportedData = { isSupported: true };
+  let today = _today || new Date();
+  let diffType = semver.diff(parsed, latestVersion);
+  if (diffType) {
+    let deprecationDate = findDeprecationDate(version, info, diffType);
+    let deprecationPolicyDates = deprecationDates(deprecationDate);
+    const result = dateDiff(deprecationPolicyDates[diffType], today);
+    if (isNaN(result)) {
+      throw new Error(`Invalid Date: ${deprecationDates(deprecationDate)[diffType]} - ${today}`);
+    }
+
+    if (result <= 0) {
+      let policy = policies.filter(_policy => _policy.type === diffType);
+      return {
+        isSupported: false,
+        message: `violated: ${policy[0].name}`,
+        duration: Math.abs(result),
+        type: diffType,
+        deprecationDate: deprecationPolicyDates[diffType].toISOString(),
+      };
+    } else if (isExpiringSoon(result)) {
+      return {
+        isSupported: true,
+        duration: result,
+        type: diffType,
+        deprecationDate: deprecationPolicyDates[diffType].toISOString(),
+      };
+    }
   }
-  return { isSupported: true };
+  return supportedData;
 }

--- a/lib/time/index.js
+++ b/lib/time/index.js
@@ -89,7 +89,7 @@ function findDeprecationDate(_version, info, type) {
   semver.sort(versionArray);
   let indexCurrent = versionArray.indexOf(_version);
   let currentParsed = semver.parse(_version);
-  let nextVersion = '';
+  let nextVersion = _version;
   for (let i = indexCurrent + 1; i < versionArray.length; i++) {
     let version = semver.parse(versionArray[i]);
     if (semver.diff(versionArray[i], currentParsed) === type) {
@@ -118,7 +118,11 @@ function supported(info, packageName, policies, _today) {
     let deprecationPolicyDates = deprecationDates(deprecationDate);
     const result = dateDiff(deprecationPolicyDates[diffType], today);
     if (isNaN(result)) {
-      throw new Error(`Invalid Date: ${deprecationDates(deprecationDate)[diffType]} - ${today}`);
+      throw new Error(
+        `Invalid Date: ${deprecationDates(deprecationDate)[diffType]} - ${today}, name: ${
+          info.name
+        }`,
+      );
     }
 
     if (result <= 0) {

--- a/lib/time/index.js
+++ b/lib/time/index.js
@@ -39,6 +39,11 @@ function supportedRanges(_origin) {
 }
 
 module.exports.deprecationDates = deprecationDates;
+/**
+ * calculates the major, minor and patch version deprecation dates for the given release date
+ * if release occured at the end of quarter, add a padding of one quarter.
+ * @param {Date} _release : release date of next version
+ */
 function deprecationDates(_release) {
   const release = new Date(_release);
   const major = new Date(release);
@@ -71,6 +76,12 @@ function deprecationDates(_release) {
 }
 
 module.exports.findDeprecationDate = findDeprecationDate;
+/**
+ * finds the next version release date wrt the type of violation.
+ * @param {string} _version: current installed version in the project.
+ * @param {object} info information recieved from the artifactory
+ * @param {'major'|'minor'|'patch'} type type of violation with current vs latest
+ */
 function findDeprecationDate(_version, info, type) {
   let allRelease = info.time;
   let versionArray = Object.keys(allRelease);
@@ -101,6 +112,8 @@ function supported(info, packageName, policies, _today) {
   let today = _today || new Date();
   let diffType = semver.diff(parsed, latestVersion);
   if (diffType) {
+    // deprecation for the current used version start when version next to is released not always when latest is released.
+    // Ex: if version 2.0.0 is being currently being used, and the latest is 4.0.0, the deprecation of the 2.0.0 starts when 3.0.0 is released.
     let deprecationDate = findDeprecationDate(version, info, diffType);
     let deprecationPolicyDates = deprecationDates(deprecationDate);
     const result = dateDiff(deprecationPolicyDates[diffType], today);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const semver = require('semver');
 const moment = require('moment');
 
 // 91 days in a quarter, 24hrs per day, 60 minutes per hour, 60 seconds per hour, 1000 millseconds per sec
@@ -22,6 +23,15 @@ function dateDiff(a, b) {
   const utc2 = moment.utc(b);
 
   return utc1.diff(utc2);
+}
+
+function getLatest(info) {
+  let versionArray = Object.keys(info.time);
+  versionArray = versionArray.filter(
+    version => semver.valid(version) && !semver.prerelease(version),
+  );
+  semver.sort(versionArray);
+  return versionArray[versionArray.length - 1];
 }
 
 /**
@@ -68,4 +78,5 @@ module.exports = {
   MILLSINQUARTER,
   sortLibraries,
   dateDiff,
+  getLatest,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const semver = require('semver');
 const moment = require('moment');
 
 // 91 days in a quarter, 24hrs per day, 60 minutes per hour, 60 seconds per hour, 1000 millseconds per sec
@@ -25,13 +24,12 @@ function dateDiff(a, b) {
   return utc1.diff(utc2);
 }
 
+/**
+ *
+ * @param {InfoObject} info information about package recived from the npm registry
+ */
 function getLatest(info) {
-  let versionArray = Object.keys(info.time);
-  versionArray = versionArray.filter(
-    version => semver.valid(version) && !semver.prerelease(version),
-  );
-  semver.sort(versionArray);
-  return versionArray[versionArray.length - 1];
+  return info['dist-tags'].latest;
 }
 
 /**

--- a/tests/ember-lts-test.js
+++ b/tests/ember-lts-test.js
@@ -218,6 +218,7 @@ describe('ember LTS Policy based policy', function () {
     it('resolved version is LTS', function () {
       let currentDate = new Date(`2021-02-24T22:56:00.185Z`);
       expect(isLtsOrLatest({}, '3.16.0', currentDate)).to.eql({
+        deprecationDate: '2021-03-17T00:00:00.000Z',
         isSupported: true,
         duration: 1731839815,
         message: 'Using maintenance LTS. Update to latest LTS',
@@ -229,6 +230,7 @@ describe('ember LTS Policy based policy', function () {
     it('resolved version is older version', function () {
       let currentDate = new Date(`2021-02-22T22:56:00.185Z`);
       expect(isLtsOrLatest({}, '3.14.0', currentDate)).to.eql({
+        deprecationDate: '2020-08-24T00:00:00.000Z',
         isSupported: false,
         duration: 15807360185,
         message: 'ember-cli needs to be on v3.20.* or above LTS version',
@@ -239,6 +241,7 @@ describe('ember LTS Policy based policy', function () {
     it('Above maintenance LTS, update to next LTS', function () {
       let currentDate = new Date(`2021-02-24T22:56:00.185Z`);
       expect(isLtsOrLatest({}, '3.18.0', currentDate)).to.eql({
+        deprecationDate: '2020-08-24T00:00:00.000Z',
         isSupported: false,
         duration: 15980160185,
         message: 'ember-cli needs to be on v3.20.* or above LTS version',

--- a/tests/fixtures/recordings/stefanpenner/@stefanpenner/b.json
+++ b/tests/fixtures/recordings/stefanpenner/@stefanpenner/b.json
@@ -1,0 +1,59 @@
+{
+  "_id": "@stefanpenner/a@1.0.3",
+  "_rev": "4-900a5863c49b3df17b1e38f4366ba8ac",
+  "name": "@stefanpenner/a",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": [
+    "1.0.0",
+    "1.0.1",
+    "1.0.2",
+    "1.0.3",
+    "2.0.0"
+  ],
+  "maintainers": [
+    "stefanpenner <stefan.penner@gmail.com>"
+  ],
+  "time": {
+    "modified": "2016-09-21T16:12:48.054Z",
+    "created": "2015-08-17T22:40:20.281Z",
+    "1.0.0": "2015-08-17T22:40:20.281Z",
+    "1.0.1": "2015-08-18T15:28:48.461Z",
+    "1.0.2": "2015-08-18T15:29:39.933Z",
+    "1.0.3": "2020-09-21T16:12:48.054Z",
+    "2.0.0": "2021-01-21T16:12:48.054Z"
+  },
+  "license": "ISC",
+  "readmeFilename": "",
+  "_attachments": {},
+  "_cached": true,
+  "_contentLength": 0,
+  "version": "1.0.3",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "peerDependencies": {
+    "@stefanpenner/b": "^1.0.0"
+  },
+  "dependencies": {
+    "lodash": "^4.16.1"
+  },
+  "_shasum": "8aa6b161063526bbd954289bbfe36f6660a02ab9",
+  "_from": ".",
+  "_npmVersion": "3.10.3",
+  "_nodeVersion": "6.6.0",
+  "_npmUser": "stefanpenner <stefan.penner@gmail.com>",
+  "dist": {
+    "shasum": "8aa6b161063526bbd954289bbfe36f6660a02ab9",
+    "tarball": "https://registry.npmjs.org/@stefanpenner/a/-/a-1.0.3.tgz"
+  },
+  "_npmOperationalInternal": {
+    "host": "packages-16-east.internal.npmjs.com",
+    "tmp": "tmp/a-1.0.3.tgz_1474474366275_0.895244502928108"
+  },
+  "directories": {}
+}

--- a/tests/fixtures/version-expire-soon/package.json
+++ b/tests/fixtures/version-expire-soon/package.json
@@ -2,7 +2,7 @@
   "name": "version-expiring-soon",
   "dependencies": {
     "@eslint-ast/eslint-plugin-graphql": "^1.0.4",
-    "@stefanpenner/a": "^1.0.3",
+    "@stefanpenner/b": "^1.0.3",
     "rsvp": "^4.8.0"
   },
   "devDependencies": {

--- a/tests/fixtures/version-expire-soon/yarn.lock
+++ b/tests/fixtures/version-expire-soon/yarn.lock
@@ -12,9 +12,9 @@
     mocha "^8.1.0"
     resolve "^1.17.0"
 
-"@stefanpenner/a@^1.0.3":
+"@stefanpenner/b@^1.0.3":
   version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@stefanpenner/a/-/a-1.0.3.tgz#8aa6b161063526bbd954289bbfe36f6660a02ab9"
+  resolved "https://registry.yarnpkg.com/@stefanpenner/b/-/b-1.0.3.tgz#8aa6b161063526bbd954289bbfe36f6660a02ab9"
   integrity sha1-iqaxYQY1JrvZVCibv+NvZmCgKrk=
   dependencies:
     lodash "^4.16.1"

--- a/tests/node-lts-test.js
+++ b/tests/node-lts-test.js
@@ -36,6 +36,7 @@ describe('node LTS Policy based policy', function () {
     it('node version with range', function () {
       let currentDate = new Date(`2021-02-24T00:00:00.000Z`);
       expect(isLtsOrLatest({ type: 'node' }, '10.* || 12.* || 14.* || >= 15', currentDate)).to.eql({
+        deprecationDate: '2021-04-30T00:00:00.000Z',
         isSupported: true,
         duration: 5616000000,
         message: 'Using maintenance LTS. Update to latest LTS',
@@ -63,6 +64,7 @@ describe('node LTS Policy based policy', function () {
     it('node version with below and in support range value', function () {
       let currentDate = new Date(`2021-02-24T00:00:00.000Z`);
       expect(isLtsOrLatest({ type: 'node' }, '8.* || 10.*', currentDate)).to.eql({
+        deprecationDate: '2021-04-30T00:00:00.000Z',
         isSupported: true,
         duration: 5616000000,
         message: 'Using maintenance LTS. Update to latest LTS',
@@ -74,6 +76,7 @@ describe('node LTS Policy based policy', function () {
     it('node version with fixed value below LTS range', function () {
       const fakeToday = new Date(`2021-02-22T00:00:00.000Z`);
       expect(isLtsOrLatest({ type: 'node' }, '8.0.0', fakeToday)).to.eql({
+        deprecationDate: '2020-10-27T00:00:00.000Z',
         isSupported: false,
         duration: 10195200000,
         message: `node needs to be on v14.* or above LTS version`,
@@ -84,6 +87,7 @@ describe('node LTS Policy based policy', function () {
     it('node version with range value below LTS', function () {
       const fakeToday = new Date(`2021-02-22T00:00:00.000Z`);
       expect(isLtsOrLatest({ type: 'node' }, '6.* || 8.*', fakeToday)).to.eql({
+        deprecationDate: '2020-10-27T00:00:00.000Z',
         isSupported: false,
         duration: 10195200000,
         message: `node needs to be on v14.* or above LTS version`,
@@ -96,6 +100,7 @@ describe('node LTS Policy based policy', function () {
       const nextDay = new Date(lastDay);
       nextDay.setDate(nextDay.getDate() + 1);
       expect(isLtsOrLatest({ type: 'node' }, '10.2.0', nextDay)).to.eql({
+        deprecationDate: '2020-10-27T00:00:00.000Z',
         isSupported: false,
         duration: 16070400000,
         message: `node needs to be on v14.* or above LTS version`,

--- a/tests/project-test.js
+++ b/tests/project-test.js
@@ -65,8 +65,11 @@ describe('project-1', function () {
     // purge out the duration from node entry from out
     // because we use `new Date` to calculate the duration
     result.supportChecks.forEach(pkg => {
-      if (pkg.name == 'node') {
+      if (pkg.duration) {
+        expect(pkg.duration).to.be.a('number');
+        expect(pkg.deprecationDate).to.be.a('string');
         delete pkg['duration'];
+        delete pkg['deprecationDate'];
       }
     });
 
@@ -77,7 +80,6 @@ describe('project-1', function () {
         {
           isSupported: false,
           message: 'violated: major version must be within 1 year of latest',
-          duration: 54431779121,
           type: 'major',
           name: 'es6-promise',
           resolvedVersion: '3.3.1',
@@ -85,8 +87,15 @@ describe('project-1', function () {
         },
         {
           isSupported: false,
+          latestVersion: '2.0.0',
           message: 'violated: major version must be within 1 year of latest',
-          duration: 27959197042,
+          name: '@stefanpenner/a',
+          resolvedVersion: '1.0.3',
+          type: 'major',
+        },
+        {
+          isSupported: false,
+          message: 'violated: major version must be within 1 year of latest',
           type: 'major',
           name: 'rsvp',
           resolvedVersion: '3.6.2',
@@ -98,14 +107,6 @@ describe('project-1', function () {
           latestVersion: '>=14.*',
           message: 'Using maintenance LTS. Update to latest LTS',
           name: 'node',
-        },
-        {
-          isSupported: true,
-          duration: 21081600000,
-          type: 'major',
-          name: '@stefanpenner/a',
-          resolvedVersion: '1.0.3',
-          latestVersion: '2.0.0',
         },
         {
           isSupported: true,
@@ -168,8 +169,11 @@ describe('project-1', function () {
     // purge out the duration from node entry from out
     // because we use `new Date` to calculate the duration
     result.supportChecks.forEach(pkg => {
-      if (pkg.name == 'node') {
+      if (pkg.duration) {
+        expect(pkg.duration).to.be.a('number');
+        expect(pkg.deprecationDate).to.be.a('string');
         delete pkg['duration'];
+        delete pkg['deprecationDate'];
       }
     });
     expect(result).to.eql({
@@ -185,9 +189,8 @@ describe('project-1', function () {
         },
         {
           isSupported: true,
-          duration: 21081600000,
           type: 'major',
-          name: '@stefanpenner/a',
+          name: '@stefanpenner/b',
           resolvedVersion: '1.0.3',
           latestVersion: '2.0.0',
         },

--- a/tests/time-based-test.js
+++ b/tests/time-based-test.js
@@ -195,15 +195,15 @@ describe('time based policy: 1 year for major, 6 months for minor, 3 months of p
   describe(`deprecationDates`, function () {
     it(`returns deprecation dates`, function () {
       let dates = deprecationDates('2019-01-08T16:30:15.184Z');
-      expect(dates.major.toISOString()).to.eql('2020-01-08T16:30:15.184Z');
-      expect(dates.minor.toISOString()).to.eql('2019-07-08T15:30:15.184Z');
-      expect(dates.patch.toISOString()).to.eql('2019-04-08T15:30:15.184Z');
+      expect(dates.major.toDateString()).to.eql('Wed Jan 08 2020');
+      expect(dates.minor.toDateString()).to.eql('Mon Jul 08 2019');
+      expect(dates.patch.toDateString()).to.eql('Mon Apr 08 2019');
     });
     it(`returns deprecation dates with padding`, function () {
       let dates = deprecationDates('2019-03-25T16:30:15.184Z');
-      expect(dates.major.toISOString()).to.eql('2020-06-25T16:30:15.184Z');
-      expect(dates.minor.toISOString()).to.eql('2019-12-25T17:30:15.184Z');
-      expect(dates.patch.toISOString()).to.eql('2019-09-25T16:30:15.184Z');
+      expect(dates.major.toDateString()).to.eql('Thu Jun 25 2020');
+      expect(dates.minor.toDateString()).to.eql('Wed Dec 25 2019');
+      expect(dates.patch.toDateString()).to.eql('Wed Sep 25 2019');
     });
   });
 });

--- a/tests/time-based-test.js
+++ b/tests/time-based-test.js
@@ -3,11 +3,27 @@
 const chai = require('chai');
 const { expect } = chai;
 const fs = require('fs');
-const { supported, supportedRanges } = require('../lib/time/index');
+const {
+  supported,
+  supportedRanges,
+  findDeprecationDate,
+  deprecationDates,
+} = require('../lib/time/index');
 
 chai.use(require('chai-datetime'));
 
+function verifyTime(result) {
+  if (result.duration) {
+    expect(result.duration).to.be.a('number');
+    expect(result.deprecationDate).to.be.a('string');
+    delete result['duration'];
+    delete result['deprecationDate'];
+  }
+  return result;
+}
+
 describe('time based policy: 1 year for major, 6 months for minor, 3 months of patch.', function () {
+  let currentDate = new Date(`2021-02-24T22:56:00.185Z`);
   it('supported ranges', function () {
     const origin = new Date('1986-09-16');
     const result = supportedRanges(origin);
@@ -39,32 +55,6 @@ describe('time based policy: 1 year for major, 6 months for minor, 3 months of p
         [],
       ),
     ).to.eql({ isSupported: true });
-  });
-
-  it('throws if latest version has no published time', function () {
-    expect(() =>
-      supported(
-        {
-          version: '1.0.0',
-          time: {},
-        },
-        'example@1.0.0',
-        [],
-      ),
-    ).to.throw("example's version: [1.0.0] has no published time");
-  });
-
-  it('throws useful error version has no published time', function () {
-    expect(() =>
-      supported(
-        {
-          version: '1.0.0',
-          time: {},
-        },
-        'example@3.22.0',
-        [],
-      ),
-    ).to.throw("example's version: [3.22.0] has no published time");
   });
 
   it('returns true, when no policies are provide but versions have been published', function () {
@@ -106,9 +96,11 @@ describe('time based policy: 1 year for major, 6 months for minor, 3 months of p
             date: new Date('1985-09-16'),
           },
         ],
+        currentDate,
       ),
     ).to.eql({
-      duration: 86400000,
+      deprecationDate: `1987-09-16T00:00:00.000Z`,
+      duration: 1055458560185,
       isSupported: false,
       message: 'violated: 1 year window',
       type: 'major',
@@ -121,18 +113,18 @@ describe('time based policy: 1 year for major, 6 months for minor, 3 months of p
     );
     const policies = supportedRanges(info.time[info.version]);
 
-    expect(supported(info, 'console-ui@3.1.2', policies)).to.eql({ isSupported: true });
-    let result = supported(info, 'console-ui@3.1.0', policies);
-    expect(typeof result.duration).to.eql('number');
-    delete result.duration;
+    expect(supported(info, 'console-ui@3.1.2', policies, currentDate)).to.eql({
+      isSupported: true,
+    });
+    let result = supported(info, 'console-ui@3.1.0', policies, currentDate);
+    result = verifyTime(result);
     expect(result).to.eql({
       isSupported: false,
       message: 'violated: patch version must be within 3 months of latest',
       type: 'patch',
     });
-    result = supported(info, 'console-ui@2.0.0', policies);
-    expect(typeof result.duration).to.eql('number');
-    delete result.duration;
+    result = supported(info, 'console-ui@2.0.0', policies, currentDate);
+    result = verifyTime(result);
     expect(result).to.eql({
       isSupported: false,
       message: 'violated: major version must be within 1 year of latest',
@@ -146,53 +138,72 @@ describe('time based policy: 1 year for major, 6 months for minor, 3 months of p
     );
     const policies = supportedRanges(info.time[info.version]);
 
-    expect(supported(info, 'ember-cli@3.22.0', policies)).to.eql({ isSupported: true });
-    expect(supported(info, 'ember-cli@3.21.0', policies)).to.eql({
-      duration: 11840496435,
+    expect(supported(info, 'ember-cli@3.22.0', policies, currentDate)).to.eql({
+      isSupported: true,
+    });
+    let result = supported(info, 'ember-cli@3.21.0', policies, currentDate);
+    verifyTime(result);
+    expect(result).to.eql({
       isSupported: true,
       type: 'minor',
     });
-    expect(supported(info, 'ember-cli@3.20.0', policies)).to.eql({
-      duration: 8756624607,
+    result = supported(info, 'ember-cli@3.20.0', policies, currentDate);
+    verifyTime(result);
+    expect(result).to.eql({
       isSupported: true,
       type: 'minor',
     });
-    expect(supported(info, 'ember-cli@3.12.1', policies)).to.eql({
-      duration: 11061239038,
+    result = supported(info, 'ember-cli@3.12.1', policies, currentDate);
+    verifyTime(result);
+    expect(result).to.eql({
       isSupported: false,
       message: 'violated: minor version must be within 6 months of latest',
       type: 'minor',
     });
-    expect(supported(info, 'ember-cli@3.13.2', policies)).to.eql({
-      duration: 13308317989,
+    result = supported(info, 'ember-cli@3.13.2', policies, currentDate);
+    verifyTime(result);
+    expect(result).to.eql({
       isSupported: false,
       message: 'violated: minor version must be within 6 months of latest',
       type: 'minor',
     });
-    expect(supported(info, 'ember-cli@3.13.1', policies)).to.eql({
-      duration: 17517994037,
+    result = supported(info, 'ember-cli@3.13.1', policies, currentDate);
+    verifyTime(result);
+    expect(result).to.eql({
       isSupported: false,
       message: 'violated: minor version must be within 6 months of latest',
       type: 'minor',
     });
-    expect(supported(info, 'ember-cli@3.4.0', policies)).to.eql({
-      duration: 50945222713,
+    result = supported(info, 'ember-cli@3.4.0', policies, currentDate);
+    verifyTime(result);
+    expect(result).to.eql({
       isSupported: false,
       message: 'violated: minor version must be within 6 months of latest',
       type: 'minor',
     });
+  });
 
-    expect(() => supported(info, 'ember-cli@^3.0.0', policies)).to.throw(
-      'version: [^3.0.0] has no published time',
+  describe(`findDeprecationDate`, function () {
+    const info = JSON.parse(
+      fs.readFileSync(`${__dirname}/fixtures/recordings/default/console-ui.json`, 'UTF8'),
     );
-    expect(() => supported(info, 'ember-cli@3.0.x', policies)).to.throw(
-      'version: [3.0.x] has no published time',
-    );
-    expect(() => supported(info, 'ember-cli@^2.0.0', policies)).to.throw(
-      'version: [^2.0.0] has no published time',
-    );
-    expect(() => supported(info, 'ember-cli@1.0.0', policies)).to.throw(
-      'version: [1.0.0] has no published time',
-    );
+    it(`able to find deprecation dates`, function () {
+      let date = findDeprecationDate('2.2.3', info, 'major');
+      expect(date.toISOString()).to.eql('2019-01-08T16:30:15.184Z');
+    });
+  });
+  describe(`deprecationDates`, function () {
+    it(`returns deprecation dates`, function () {
+      let dates = deprecationDates('2019-01-08T16:30:15.184Z');
+      expect(dates.major.toISOString()).to.eql('2020-01-08T16:30:15.184Z');
+      expect(dates.minor.toISOString()).to.eql('2019-07-08T15:30:15.184Z');
+      expect(dates.patch.toISOString()).to.eql('2019-04-08T15:30:15.184Z');
+    });
+    it(`returns deprecation dates with padding`, function () {
+      let dates = deprecationDates('2019-03-25T16:30:15.184Z');
+      expect(dates.major.toISOString()).to.eql('2020-06-25T16:30:15.184Z');
+      expect(dates.minor.toISOString()).to.eql('2019-12-25T17:30:15.184Z');
+      expect(dates.patch.toISOString()).to.eql('2019-09-25T16:30:15.184Z');
+    });
   });
 });


### PR DESCRIPTION
If version `2.0.0` is being currently being used, and the latest is `4.0.0`, the deprecation of the `2.0.0` starts when `3.0.0` is released. We cannot consider the release date of the latest version all the time.

If the version is released two weeks before the end of the quarter, we shouldn't consider the next quarter for deprecation. Deprecation starts a quarter after that ( we need to add padding of 3 months).