### PR TITLE
Make CI green

### DIFF
--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -19,6 +19,10 @@ async function runSupportedCmd(inputArgs) {
 }
 
 describe('CLI', function () {
+  // TODO: Check if we can remove this timeout increase and fix the npm config logic to be fast
+  // Test in windows are failing
+  // Issue may be caused by npmconfig command we have in the code base. For now we are increasing the timeout.
+  this.timeout(4000);
   beforeEach(function () {
     registries.startAll();
   });
@@ -76,9 +80,6 @@ describe('CLI', function () {
     });
 
     it('works against multiple project', async function () {
-      // Test in windows are failing
-      // Issue may be caused by npmconfig command we have in the code base. For now we are increasing the timeout.
-      this.timeout(4000);
       const child = await runSupportedCmd([
         `${__dirname}/fixtures/supported-project`,
         `${__dirname}/fixtures/unsupported-project`,


### PR DESCRIPTION
We have to run cli tests with extra time than the default for following reasons
1. we spawn a node instance to run the CLI command
2. Each CLI command spawns one more shell to get npm config.

This may run little slow in windows at times.
For now we can fix the test timeout.