### PR TITLE
Export tests so that developers can utilize the testing infra

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,9 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "get-bin-path": "^5.1.0",
-    "koa": "^2.13.0",
-    "koa-logger": "^3.2.1",
     "mocha": "^8.2.1",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.2.0",
-    "resolve-path": "^1.4.0"
+    "prettier": "^2.2.0"
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
@@ -52,6 +49,8 @@
     "execa": "^5.0.0",
     "ini": "^1.3.7",
     "json2csv": "^5.0.6",
+    "koa": "^2.13.0",
+    "koa-logger": "^3.2.1",
     "meow": "^8.0.0",
     "minipass-fetch": "^1.3.2",
     "moment": "^2.29.1",
@@ -61,12 +60,14 @@
     "p-queue": "^6.6.2",
     "parse-package-name": "^0.1.0",
     "promise.allsettled": "^1.0.4",
+    "resolve-path": "^1.4.0",
     "semver": "^7.3.4",
     "strip-ansi": "^6.0.0",
     "terminal-link": "^2.1.1"
   },
   "files": [
     "lib",
-    "bin"
+    "bin",
+    "tests/test-helpers"
   ]
 }

--- a/tests/cli-test.js
+++ b/tests/cli-test.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const execa = require('execa');
 const { getBinPath } = require('get-bin-path');
 const fs = require('fs');
-const registries = require('./registries');
+const registries = require('./test-helpers/registries');
 const { join } = require('path');
 
 async function runSupportedCmd(inputArgs) {

--- a/tests/project-test.js
+++ b/tests/project-test.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const isInSupportWindow = require('../lib/project');
 const setupProject = require('../lib/project/setup-project');
 const { ProgressLogger } = require('../lib/util');
-const registries = require('./registries');
+const registries = require('./test-helpers/registries');
 
 describe('project-1', function () {
   const root = `${__dirname}/fixtures`;

--- a/tests/test-helpers/helpers.js
+++ b/tests/test-helpers/helpers.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { existsSync, readdirSync } = require('fs');
+const { join } = require('path');
+
+function getTestProjectPath(projectName) {
+  const root = `${__dirname}/../fixtures`;
+  const projectPath = join(root, projectName);
+  if (existsSync(projectPath)) {
+    return projectPath;
+  }
+  throw new Error(`Unable to find ${projectName} at ${root}`);
+}
+
+function getAvaiableTestProjects() {
+  return readdirSync(`${__dirname}/../fixtures`, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory() && dirent.name !== 'recordings')
+    .map(dirent => dirent.name);
+}
+
+module.exports = {
+  getTestProjectPath,
+  getAvaiableTestProjects,
+};

--- a/tests/test-helpers/registries.js
+++ b/tests/test-helpers/registries.js
@@ -3,6 +3,7 @@
 const Koa = require('koa');
 const fs = require('fs');
 const resolve = require('resolve-path');
+const BASE_PORT = 3000;
 
 // disable inherited registry (when calling yarn <run> you get this set...)
 delete process.env.npm_config_registry;
@@ -38,18 +39,22 @@ function server(recordingRoot, port) {
 }
 
 {
-  const root = `${__dirname}/fixtures`;
+  const root = `${__dirname}/../fixtures`;
   let registries = null;
-  module.exports.startAll = function () {
+  module.exports.startAll = function (additionalRegistries = []) {
     if (registries !== null) {
       throw new Error('already started');
     }
     registries = Object.create(null);
     // default registry
-    registries.default = server(`${root}/recordings/default`, 3000);
+    registries.default = server(`${root}/recordings/default`, BASE_PORT);
 
     // registry for the @stefanpenner scope
-    registries.stefanpenner = server(`${root}/recordings/stefanpenner`, 3001);
+    registries.stefanpenner = server(`${root}/recordings/stefanpenner`, BASE_PORT + 1);
+    // if developers want to add more server while extending
+    additionalRegistries.forEach(({ name, recordingRoot }, index) => {
+      registries[name] = server(recordingRoot, BASE_PORT + 2 + index);
+    });
   };
 
   module.exports.stopAll = function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,10 +1633,10 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
-lodash@^4.17.14, lodash@^4.17.19:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@4.0.0, log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This will allow developers who are extending this project can utilize the already existing test infra in this library. 
```js
const registries = require('supported/tests/test-helpers/registries');
const { getProjectPath } = require('supported/tests/test-helpers/helpers');

describe('default output', function () {
    it('works against a one project', async function () {
      registries.startAll([{
         name: 'newProject',
         recordingRoot: `${__dirname}/fixtures/recordings/new-project`,
       }]);
      const child = await execa(
        'node',
        [await getBinPath(), getProjectPath('supported-project')],
        {
          shell: true,
          reject: false,
        }
      );
      expect(child.exitCode).to.eql(0);
      expect(child.stderr).to.include('✓ node LTS Policy');
      expect(child.stdout).to.include('✓ Congrats!');
      registries.stopAll();
    });
});
```