### PR TITLE
Show nice error for old npm versions

### DIFF
--- a/lib/npm/config.js
+++ b/lib/npm/config.js
@@ -8,6 +8,15 @@ module.exports = async function (cwd) {
     cwd,
     // shell: true,
   });
+  let jsonConfigOutput = '';
 
-  return camelcaseKeys(JSON.parse(child.stdout));
+  try {
+    jsonConfigOutput = JSON.parse(child.stdout);
+  } catch (e) {
+    throw new Error(
+      `'npm config list --json' did not return a valid JSON result. Please make sure you are on npm v7 or greater.`,
+    );
+  }
+
+  return camelcaseKeys(jsonConfigOutput);
 };


### PR DESCRIPTION
Old versions of npm do not support the `--json` flag in `npm config list --json`, which is currently expected.

<img width="889" alt="Screen Shot 2021-03-19 at 4 01 44 PM" src="https://user-images.githubusercontent.com/597574/111850129-a2be0480-88cc-11eb-80b3-b6d63e4d1808.png">
