### PR TITLE
Fix coloring output

### DIFF
--- a/lib/output/messages.js
+++ b/lib/output/messages.js
@@ -29,7 +29,7 @@ const LOG_SEMVER_VIOLATION = (type, total, duration, isWarning) => {
     return chalk`
       {yellow ⚠ ${type} [${total} ${getDepLocale(total)} will expire within ${qtrs} ${getQtrLocale(
       qtrs,
-    )}}]`;
+    )}]}`;
   }
 };
 


### PR DESCRIPTION
I noticed that we accidentally closed the "yellow" warning colour, one character too soon.

Test failures are unrelated to this, rather our existing tests need to be made more resilient to time/support policy drfiting.