### PR TITLE
[Fixes #26] if `supported` is run without inputs in a directory that …

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,6 @@
 'use strict';
 //check for node version as first thing
-const { checkNodeCompatibility, processDate } = require('../lib/util');
+const { checkNodeCompatibility, processDate, handleInput } = require('../lib/util');
 checkNodeCompatibility();
 
 // proceed iff the node version is good.
@@ -11,11 +11,12 @@ const { DEFAULT_SUPPORT_MESSAGE } = require('./output/messages');
 const { generateCsv } = require('../lib/output/csv-output');
 
 async function main(cli, { policyDetails, setupProjectFn }) {
-  if (cli.input.length === 0) {
+  const projectPaths = handleInput(cli.input, process.cwd());
+
+  if (projectPaths.length === 0) {
     cli.showHelp(1);
   } else {
     const currentDate = processDate(cli.flags.currentDate) || undefined;
-    const projectPaths = cli.input;
 
     const spinner = ora('working').start();
     let result;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const chalk = require('chalk');
 const moment = require('moment');
 const { readFileSync } = require('fs');
@@ -194,5 +195,40 @@ module.exports.processDate = function processDate(inputDate) {
   } else {
     // able to parse date normally, use that date
     return date;
+  }
+};
+
+/*
+ *
+ * Provide the logic to handle `supported` both with a list of project directories and without.
+ *
+ * The algorithm is more or less:
+ *
+ * If a list of directories is used, each directory will be considered a project.
+ * If no directory is provided, and the CWD contains a valid looking
+ * package.json, we assume the user wants to run supported in CWD.
+ *
+ */
+module.exports.handleInput = function (input, cwd) {
+  if (input.length === 0) {
+    try {
+      JSON.parse(fs.readFileSync(`${cwd}/package.json`, 'UTF-8'));
+      // if the cwd contains a JSON file named `package.json` so we assume the
+      // user wanted to run the command on the current directory
+      return ['.'];
+    } catch (e) {
+      if (
+        e !== null &&
+        typeof e === 'object' &&
+        (e.code === 'ENOENT' || e.name === 'SyntaxError')
+      ) {
+        // no package.json exists at that location as a readable json file, so we
+        // are should instead display our help dialog.
+        return [];
+      }
+      throw e; // not sure what happened, let's rethrow
+    }
+  } else {
+    return input;
   }
 };

--- a/tests/util-test.js
+++ b/tests/util-test.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai');
 const { expect } = chai;
-const { sortLibraries, checkNodeCompatibility } = require('../lib/util');
+const { sortLibraries, checkNodeCompatibility, handleInput } = require('../lib/util');
 
 chai.use(require('chai-datetime'));
 
@@ -151,6 +151,25 @@ describe('util test', function () {
       expect(processDate('1 day')).to.equalDate(tomorrow);
       expect(processDate('-1 day')).to.equalDate(yesterday);
       expect(processDate('Sept 16, 1986')).to.equalDate(new Date('Sept 16, 1986'));
+    });
+  });
+
+  describe('handleInput', function () {
+    it('return the correct set of paths for various cli inputs', function () {
+      expect(handleInput([], `${__dirname}/../`)).to.eql(['.']);
+      expect(handleInput([], `${__dirname}/`)).to.eql([]);
+      expect(handleInput([`${__dirname}/fixtures/supported-project/`], `${__dirname}/../`)).to.eql([
+        `${__dirname}/fixtures/supported-project/`,
+      ]);
+      expect(
+        handleInput(
+          [`${__dirname}/fixtures/supported-project/`, `${__dirname}/fixtures/unsupported-project`],
+          `${__dirname}/../`,
+        ),
+      ).to.eql([
+        `${__dirname}/fixtures/supported-project/`,
+        `${__dirname}/fixtures/unsupported-project`,
+      ]);
     });
   });
 });


### PR DESCRIPTION
…appears to be a a valid project, assume that is the project we want to run supported against