### PR TITLE
Handle prereleases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 tests/fixtures/*/node_modules/
+.DS_Store

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,12 +33,24 @@ function dateDiff(a, b) {
 }
 
 /**
- *
+ * Return the latest version string, ignoring pre-releases.
  * @param {InfoObject} info information about package received from the npm registry
  */
 module.exports.getLatest = getLatest;
 function getLatest(info) {
-  return info['dist-tags'].latest;
+  const literalLatest = info['dist-tags'].latest;
+  if (semver.parse(literalLatest).prerelease.length === 0) {
+    return literalLatest;
+  } else {
+    return Object.keys(info.versions)
+      .filter(version => {
+        return semver.parse(version).prerelease.length === 0;
+      })
+      .sort((a, b) => {
+        return semver.compare(a, b);
+      })
+      .pop();
+  }
 }
 
 /**

--- a/tests/time-based-test.js
+++ b/tests/time-based-test.js
@@ -57,6 +57,29 @@ describe('time based policy: 1 year for major, 6 months for minor, 3 months of p
     ).to.eql({ isSupported: true });
   });
 
+  it('ignores pre-releases', function () {
+    expect(
+      supported(
+        {
+          version: '1.0.0',
+          time: {
+            '1.0.0': 'never',
+          },
+          'dist-tags': {
+            latest: '2.0.0-beta.16',
+          },
+          versions: {
+            '2.0.0-beta.16': {},
+            '1.0.0': {},
+            '0.5.0': {},
+          },
+        },
+        'example@1.0.0',
+        [],
+      ),
+    ).to.eql({ isSupported: true });
+  });
+
   it('returns true, when no policies are provide but versions have been published', function () {
     expect(
       supported(


### PR DESCRIPTION
For our purposes, we want to ignore prereleases. Prereleases should not affect the support policy.

Fixes https://github.com/stefanpenner/supported/issues/34